### PR TITLE
#1: Fix to use compile API

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,4 @@ var swig = require('swig');
 
 exports.name = 'swig';
 exports.outputFormat = 'xml';
-exports.render = function (str, options) {
-  var template = swig.compile(str);
-  return template(options);
-};
+exports.compile = swig.compile;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "swig"
   ],
   "dependencies": {
-    "swig": "~1.4.2"
+    "swig": "git://github.com/TimothyGu/swig.git#patch-1"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ function assertEqual(output, expected) {
 var input = fs.readFileSync(__dirname + '/input.html.swig', 'utf8');
 var expected = fs.readFileSync(__dirname + '/expected.html', 'utf8');
 
-var options = {
+var locals = {
   title: 'Basic Example',
   people: [
     {
@@ -37,9 +37,14 @@ var options = {
       age: 45
     }
   ]
-}
-var output = transform.render(input, options);
+};
+var output = transform.compile(input)(locals);
 fs.writeFileSync(__dirname + '/output.html', output);
 assertEqual(output, expected);
 
-console.log('test passed');
+if (failed) {
+  console.log('tests FAILED');
+  process.exit(1);
+} else {
+  console.log('tests PASSED');
+}


### PR DESCRIPTION
@TimothyGu Getting this error when using [`swig.compile`](https://github.com/paularmstrong/swig/blob/master/lib/swig.js#L573):

```
    pre = this.precompile(source, options);
               ^
TypeError: Object #<Object> has no method 'precompile'
    at Object.compile (jstransformer-swig/node_modules/swig/lib/swig.js:606:16)
    at Object.<anonymous> (jstransformer-swig/test/index.js:41:24)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```

RE: #1 
